### PR TITLE
add podspec

### DIFF
--- a/Zooz.podspec
+++ b/Zooz.podspec
@@ -92,7 +92,7 @@ For more info go to https://github.com/Zooz/Zooz-iOS
   #
 
   s.source_files  = "Zooz/**/*.{h,m}"
-  s.exclude_files = "ZoozTests/**"
+  s.exclude_files = "ZoozTests/**", "Zooz/NSDictionary.{h,m}"
 
   # s.public_header_files = "Classes/**/*.h"
 

--- a/Zooz.podspec
+++ b/Zooz.podspec
@@ -91,9 +91,18 @@ For more info go to https://github.com/Zooz/Zooz-iOS
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = "Zooz/**/*.{h,m}"
-  s.exclude_files = "ZoozTests/**", "Zooz/NSDictionary.{h,m}"
+  s.subspec 'NonARC' do |ss|
+    ss.requires_arc = false
+    ss.source_files  = "Zooz/ZooZEcommSecKeyWrapper.{h,m}", "Zooz/ZooZEcommKeychainUtils.{h,m}"
+  end
 
+  s.subspec 'Core' do |ss|
+    ss.dependency 'Zooz/NonARC'
+    ss.source_files  = "Zooz/**/*.{h,m}"
+    ss.exclude_files = "ZoozTests/**", "Zooz/NSDictionary.{h,m}", "Zooz/ZooZEcommSecKeyWrapper.{h,m}", "Zooz/ZooZEcommKeychainUtils.{h,m}", "Zooz/ZoozJsonObject.{h,m}"
+  end
+
+  s.default_subspecs = 'Core'
   # s.public_header_files = "Classes/**/*.h"
 
 
@@ -130,7 +139,7 @@ For more info go to https://github.com/Zooz/Zooz-iOS
   #  where they will only apply to your library. If you depend on other Podspecs
   #  you can include multiple dependencies to ensure it works.
 
-  s.requires_arc = false
+  # s.requires_arc = ["Zooz/ZooZEcommSecKeyWrapper.m", "Zooz/ZooZEcommKeychainUtils.m"]
 
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   # s.dependency "JSONKit", "~> 1.4"

--- a/Zooz.podspec
+++ b/Zooz.podspec
@@ -1,0 +1,138 @@
+#
+#  Be sure to run `pod spec lint Zooz.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "Zooz"
+  s.version      = "1.2"
+  s.summary      = "Mobile payment SDK by Zooz."
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.description  = <<-DESC
+Mobile payment SDK by Zooz.
+For more info go to https://github.com/Zooz/Zooz-iOS
+                   DESC
+
+  s.homepage     = "http://www.zooz.com/"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "Apache License, Version 2.0"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author             = "Zooz"
+  # Or just: s.author    = "Igor Makarov"
+  # s.authors            = { "Igor Makarov" => "igor.makarov@moovitapp.com" }
+  # s.social_media_url   = "http://twitter.com/Igor Makarov"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+  s.platform     = :ios, "6.0"
+
+  #  When using multiple platforms
+  # s.ios.deployment_target = "5.0"
+  # s.osx.deployment_target = "10.7"
+  # s.watchos.deployment_target = "2.0"
+  # s.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/Zooz/Zooz-iOS.git", :tag => "#{s.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "Zooz/**/*.{h,m}"
+  s.exclude_files = "ZoozTests/**"
+
+  # s.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  s.requires_arc = false
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
+end


### PR DESCRIPTION
I've added a Podspec for you to use.
Currently I'm able to install Zooz 1.2 using the following line in my Podfile:
`pod 'Zooz', :git => "git@github.com:igor-makarov/Zooz-iOS.git", :commit => '71f1c74'` 
After merging the pull request, other developers will be able to use the following:
`pod 'Zooz', :git => "https://github.com/Zooz/Zooz-iOS.git", :commit => '71f1c74'` 
Also suggesting you push it to the main CP spec repo, so that it'll become possible to use:
`pod 'Zooz'`
